### PR TITLE
Add Dockerfile for Azure deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+build
+.git
+.gitignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+build
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+# Build stage
+FROM node:18-alpine AS build
+WORKDIR /app
+COPY package.json ./
+RUN npm install
+COPY . .
+RUN npm run build
+
+# Production stage
+FROM nginx:alpine
+COPY --from=build /app/build /usr/share/nginx/html
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,11 +1,26 @@
+# Digital Twin Platform UI
 
-  # Digital Twin Platform UI
+This is a code bundle for Digital Twin Platform UI.
 
-  This is a code bundle for Digital Twin Platform UI. 
+## Running the code
 
-  ## Running the code
+Run `npm i` to install the dependencies.
+Run `npm run dev` to start the development server.
 
-  Run `npm i` to install the dependencies.
+## Docker
 
-  Run `npm run dev` to start the development server.
-  
+Build the container image:
+```bash
+docker build -t dtal-platform .
+```
+Run the container locally:
+```bash
+docker run -p 8080:80 dtal-platform
+```
+
+## Deploying to Azure Web App Service
+
+1. Push the image to a registry such as [Azure Container Registry](https://learn.microsoft.com/azure/container-registry/).
+2. Create an Azure Web App for Containers and configure it to use the pushed image.
+
+The container listens on port 80 and serves the built static site via Nginx.


### PR DESCRIPTION
## Summary
- containerize the UI with a multi-stage Dockerfile that serves the built site via Nginx on port 80
- ignore build artifacts and `node_modules` for both Git and Docker contexts
- document how to build and run the image locally and deploy it to Azure Web App Service

## Testing
- `npm run build`
- `docker build -t dtal-platform:test .` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures not available)*
- `apt-get install -y docker.io` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_b_68b48a5cf0b8832e9c6ae9a20b909a10