### PR TITLE
feat: use text input for revenue field

### DIFF
--- a/src/components/TourismLevyCalculator.tsx
+++ b/src/components/TourismLevyCalculator.tsx
@@ -183,13 +183,11 @@ export function TourismLevyCalculator({ language, t }: TourismLevyCalculatorProp
               <Euro className="absolute left-3 top-1/2 transform -translate-y-1/2 h-4 w-4 text-muted-foreground" />
               <Input
                 id="revenue"
-                type="number"
+                type="text"
                 placeholder={t('enterAmount')}
                 value={revenue}
                 onChange={(e) => setRevenue(e.target.value)}
                 className="pl-10"
-                min="0"
-                step="0.01"
               />
             </div>
             {errors.revenue && (


### PR DESCRIPTION
## Summary
- replace revenue numeric input with a simple text field

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68b496cd6b98832e82c01114c53743e2